### PR TITLE
Fix lpc43 clocking issue

### DIFF
--- a/arm/lpc43/setup_pll.adb
+++ b/arm/lpc43/setup_pll.adb
@@ -202,7 +202,7 @@ procedure Setup_Pll is
                                            when 4 => PLL1_CTRL_ENUM_4_1,
                                            when others => PLL1_CTRL_ENUM_4_1);
 
-      MSEL : constant PLL1_CTRL_MSEL_Field := Byte (MSEL_Val);
+      MSEL : constant PLL1_CTRL_MSEL_Field := Byte (MSEL_Val - 1);
 
       delay_ticks : Integer := 500;
 
@@ -281,7 +281,8 @@ procedure Setup_Pll is
                                            when 4 => PLL1_CTRL_ENUM_4_1,
                                            when others => PLL1_CTRL_ENUM_4_1);
 
-               MIDFREQ_MSEL : constant PLL1_CTRL_MSEL_Field := Byte (MSEL_Val);
+               MIDFREQ_MSEL : constant PLL1_CTRL_MSEL_Field := Byte (MSEL_Val -
+                                                                       1);
 
             begin
 


### PR DESCRIPTION
It was determined that clock configuration issues were producing
the UART framing errors, specifically the MSEL value. The MSEL value is
PLL1's feedback divider division ratio. For a 204MHz clock, the MSEL
value should be 17, but register starts at 1 with value 0x00, so to set
MSEL to 17, the register should be set to MSEL - 1. Therefore, the
register value should be 16 not 17.